### PR TITLE
Unsaved tabs on move [3.x]

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1163,10 +1163,8 @@ void FileSystemDock::_try_move_item(const FileOrFolder &p_item, const String &p_
 						break;
 					}
 				}
-			} else if (resource_type == "GDScript" && ed->get_scene_root_script(current_tab)->get_path() == file_changed_paths[i]) {
-                // TODO, the bug persists for all scripts attached in the current tab, should do search for all attached script
-                print_verbose("LOCATED MOVED ROOT SCRIPT AND COMMENCING MOVE");
-                ScriptEditor::get_singleton()->resolve_current_scene_move(current_tab);
+			} else if (resource_type == "GDScript") {
+				ScriptEditor::get_singleton()->resolve_current_scene_move(current_tab, old_path, new_path);
             }
 		}
 
@@ -1175,8 +1173,6 @@ void FileSystemDock::_try_move_item(const FileOrFolder &p_item, const String &p_
 			p_file_renames[file_changed_paths[i]] = file_changed_paths[i].replace_first(old_path, new_path);
 			print_verbose("  Remap: " + file_changed_paths[i] + " -> " + p_file_renames[file_changed_paths[i]]);
 			emit_signal("files_moved", file_changed_paths[i], p_file_renames[file_changed_paths[i]]);
-
-            print_verbose("RESOURCE TYPE: " + ResourceLoader::get_resource_type(file_changed_paths[i]));
 		}
 		for (int i = 0; i < folder_changed_paths.size(); ++i) {
 			p_folder_renames[folder_changed_paths[i]] = folder_changed_paths[i].replace_first(old_path, new_path);

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1164,8 +1164,8 @@ void FileSystemDock::_try_move_item(const FileOrFolder &p_item, const String &p_
 					}
 				}
 			} else if (resource_type == "GDScript") {
-				ScriptEditor::get_singleton()->resolve_current_scene_move(current_tab, old_path, new_path);
-            }
+				ScriptEditor::get_singleton()->resolve_edited_scene_move(current_tab, old_path, new_path);
+			}
 		}
 
 		// Only treat as a changed dependency if it was successfully moved.

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1168,6 +1168,14 @@ void FileSystemDock::_try_move_item(const FileOrFolder &p_item, const String &p_
 			p_file_renames[file_changed_paths[i]] = file_changed_paths[i].replace_first(old_path, new_path);
 			print_verbose("  Remap: " + file_changed_paths[i] + " -> " + p_file_renames[file_changed_paths[i]]);
 			emit_signal("files_moved", file_changed_paths[i], p_file_renames[file_changed_paths[i]]);
+
+            print_verbose("RESOURCE TYPE: " + ResourceLoader::get_resource_type(file_changed_paths[i]));
+
+            // without this check and call, the script editor will create useless "[unsaved]" tabs in
+            // the script editor that are identical to the moved script, so this method must be called.
+            if (ResourceLoader::get_resource_type(file_changed_paths[i]) == "GDScript") {
+                ScriptEditor::get_singleton()->close_root_script(file_changed_paths[i]);
+            }
 		}
 		for (int i = 0; i < folder_changed_paths.size(); ++i) {
 			p_folder_renames[folder_changed_paths[i]] = folder_changed_paths[i].replace_first(old_path, new_path);

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1151,8 +1151,11 @@ void FileSystemDock::_try_move_item(const FileOrFolder &p_item, const String &p_
 		// Update scene if it is open.
 		for (int i = 0; i < file_changed_paths.size(); ++i) {
 			String new_item_path = p_item.is_file ? new_path : file_changed_paths[i].replace_first(old_path, new_path);
-			if (ResourceLoader::get_resource_type(new_item_path) == "PackedScene" && editor->is_scene_open(file_changed_paths[i])) {
-				EditorData *ed = &editor->get_editor_data();
+			String resource_type = ResourceLoader::get_resource_type(new_item_path);
+            EditorData *ed = &editor->get_editor_data();
+            int current_tab = editor->get_current_tab();
+
+            if (resource_type == "PackedScene" && editor->is_scene_open(file_changed_paths[i])) {
 				for (int j = 0; j < ed->get_edited_scene_count(); j++) {
 					if (ed->get_scene_path(j) == file_changed_paths[i]) {
 						ed->get_edited_scene_root(j)->set_filename(new_item_path);
@@ -1160,7 +1163,11 @@ void FileSystemDock::_try_move_item(const FileOrFolder &p_item, const String &p_
 						break;
 					}
 				}
-			}
+			} else if (resource_type == "GDScript" && ed->get_scene_root_script(current_tab)->get_path() == file_changed_paths[i]) {
+                print_verbose("LOCATED MOVED ROOT SCRIPT AND COMMENCING MOVE");
+//                Ref<Script> root_script = ed->get_scene_root_script(current_tab);
+                ScriptEditor::get_singleton()->resolve_root_script_move(file_changed_paths[i]);
+            }
 		}
 
 		// Only treat as a changed dependency if it was successfully moved.
@@ -1170,12 +1177,6 @@ void FileSystemDock::_try_move_item(const FileOrFolder &p_item, const String &p_
 			emit_signal("files_moved", file_changed_paths[i], p_file_renames[file_changed_paths[i]]);
 
             print_verbose("RESOURCE TYPE: " + ResourceLoader::get_resource_type(file_changed_paths[i]));
-
-            // without this check and call, the script editor will create useless "[unsaved]" tabs in
-            // the script editor that are identical to the moved script, so this method must be called.
-            if (ResourceLoader::get_resource_type(file_changed_paths[i]) == "GDScript") {
-                ScriptEditor::get_singleton()->close_root_script(file_changed_paths[i]);
-            }
 		}
 		for (int i = 0; i < folder_changed_paths.size(); ++i) {
 			p_folder_renames[folder_changed_paths[i]] = folder_changed_paths[i].replace_first(old_path, new_path);

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1149,11 +1149,11 @@ void FileSystemDock::_try_move_item(const FileOrFolder &p_item, const String &p_
 		}
 
 		// Update scene if it is open.
+        int current_tab = editor->get_current_tab();
 		for (int i = 0; i < file_changed_paths.size(); ++i) {
 			String new_item_path = p_item.is_file ? new_path : file_changed_paths[i].replace_first(old_path, new_path);
 			String resource_type = ResourceLoader::get_resource_type(new_item_path);
             EditorData *ed = &editor->get_editor_data();
-            int current_tab = editor->get_current_tab();
 
             if (resource_type == "PackedScene" && editor->is_scene_open(file_changed_paths[i])) {
 				for (int j = 0; j < ed->get_edited_scene_count(); j++) {
@@ -1164,9 +1164,9 @@ void FileSystemDock::_try_move_item(const FileOrFolder &p_item, const String &p_
 					}
 				}
 			} else if (resource_type == "GDScript" && ed->get_scene_root_script(current_tab)->get_path() == file_changed_paths[i]) {
+                // TODO, the bug persists for all scripts attached in the current tab, should do search for all attached script
                 print_verbose("LOCATED MOVED ROOT SCRIPT AND COMMENCING MOVE");
-//                Ref<Script> root_script = ed->get_scene_root_script(current_tab);
-                ScriptEditor::get_singleton()->resolve_root_script_move(file_changed_paths[i]);
+                ScriptEditor::get_singleton()->resolve_current_scene_move(current_tab);
             }
 		}
 

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -3571,46 +3571,46 @@ ScriptEditor::~ScriptEditor() {
 }
 
 void ScriptEditor::resolve_edited_scene_move(int p_scene_tab, const String &p_old_path, const String &p_new_path) {
-    EditorData *ed = &editor->get_editor_data();
+	EditorData *ed = &editor->get_editor_data();
 
-    Ref<Script> root_script = ed->get_scene_root_script(p_scene_tab);
-    String root_script_path = root_script.is_valid() ? root_script->get_path() : String();
+	Ref<Script> root_script = ed->get_scene_root_script(p_scene_tab);
+	String root_script_path = root_script.is_valid() ? root_script->get_path() : String();
 
-    Node *root = ed->get_edited_scene_root(p_scene_tab);
-    String found_path;
-    for (int i = 0; i < root->get_child_count(); ++i) {
-        Ref<Script> child_script = root->get_child(i)->get_script();
-        if (child_script.is_null()) {
-            continue;
-        }
+	Node *root = ed->get_edited_scene_root(p_scene_tab);
+	String found_path;
+	for (int i = 0; i < root->get_child_count(); ++i) {
+		Ref<Script> child_script = root->get_child(i)->get_script();
+		if (child_script.is_null()) {
+			continue;
+		}
 
-        String child_script_path = child_script->get_path();
-        if (child_script_path == p_old_path) {
-            found_path = child_script_path;
-            break;
-        }
-    }
+		String child_script_path = child_script->get_path();
+		if (child_script_path == p_old_path) {
+			found_path = child_script_path;
+			break;
+		}
+	}
 
-    if (!found_path.size() && root_script_path != p_old_path) {
-        return;
-    }
+	if (!found_path.size() && root_script_path != p_old_path) {
+		return;
+	}
 
-    for (int i = 0; i < tab_container->get_child_count(); ++i) {
-        ScriptEditorBase *seb = Object::cast_to<ScriptEditorBase>(tab_container->get_child(i));
-        if (!seb) {
-            continue;
-        }
-        String seb_path = seb->get_edited_resource()->get_path();
+	for (int i = 0; i < tab_container->get_child_count(); ++i) {
+		ScriptEditorBase *seb = Object::cast_to<ScriptEditorBase>(tab_container->get_child(i));
+		if (!seb) {
+			continue;
+		}
+		String seb_path = seb->get_edited_resource()->get_path();
 
-        if (seb_path == root_script_path && root_script_path == p_old_path) {
-            _close_tab(i, false, false);
-            return;
-        } else if (found_path == seb_path) {
-            _close_tab(i, false, false);
-            _open_script_request(p_new_path);
-            return;
-        }
-    }
+		if (seb_path == root_script_path && root_script_path == p_old_path) {
+			_close_tab(i, false, false);
+			return;
+		} else if (found_path == seb_path) {
+			_close_tab(i, false, false);
+			_open_script_request(p_new_path);
+			return;
+		}
+	}
 }
 
 void ScriptEditorPlugin::edit(Object *p_object) {

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -3570,20 +3570,46 @@ ScriptEditor::~ScriptEditor() {
 	memdelete(completion_cache);
 }
 
-// TODO, the bug persists for all scripts attached in the current tab, should do search for all attached script
-// TODO: renamed this to be more analogous for getting rid of currently attached [unsaved]'s
-void ScriptEditor::resolve_current_scene_move(int p_scene_tab) {
-    String root_script_path = editor->get_editor_data().get_scene_root_script(p_scene_tab)->get_path();
+// FIXME: Now this method works, but it also crashes if you move more than one file. Not sure if it's my fault but I assume it is.
+void ScriptEditor::resolve_current_scene_move(int p_scene_tab, const String &p_old_path, const String &p_new_path) {
+    EditorData *ed = &editor->get_editor_data();
+
+    Ref<Script> root_script = ed->get_scene_root_script(p_scene_tab);
+    String root_script_path = root_script.is_valid() ? root_script->get_path() : String();
+
+    Node *root = ed->get_edited_scene_root(p_scene_tab);
+    String found_path;
+    for (int i = 0; i < root->get_child_count(); ++i) {
+        Ref<Script> child_script = root->get_child(i)->get_script();
+        if (child_script.is_null()) {
+            continue;
+        }
+
+        String child_script_path = child_script->get_path();
+        if (child_script_path == p_old_path) {
+            found_path = child_script_path;
+            break;
+        }
+    }
+
+    if (!found_path.size() && root_script_path != p_old_path) {
+        return;
+    }
+
     for (int i = 0; i < tab_container->get_child_count(); ++i) {
         ScriptEditorBase *seb = Object::cast_to<ScriptEditorBase>(tab_container->get_child(i));
         if (!seb) {
             continue;
         }
+        String seb_path = seb->get_edited_resource()->get_path();
 
-        print_verbose(vformat("Provided path: (%s), current path: (%s)", root_script_path, seb->get_edited_resource()->get_path()));
-        if (seb->get_edited_resource()->get_path() == root_script_path) {
+        if (seb_path == root_script_path && root_script_path == p_old_path) {
             _close_tab(i, false, false);
-            break;
+            return;
+        } else if (found_path == seb_path) {
+            _close_tab(i, false, false);
+            _open_script_request(p_new_path);
+            return;
         }
     }
 }

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -3570,8 +3570,7 @@ ScriptEditor::~ScriptEditor() {
 	memdelete(completion_cache);
 }
 
-// FIXME: Now this method works, but it also crashes if you move more than one file. Not sure if it's my fault but I assume it is.
-void ScriptEditor::resolve_current_scene_move(int p_scene_tab, const String &p_old_path, const String &p_new_path) {
+void ScriptEditor::resolve_edited_scene_move(int p_scene_tab, const String &p_old_path, const String &p_new_path) {
     EditorData *ed = &editor->get_editor_data();
 
     Ref<Script> root_script = ed->get_scene_root_script(p_scene_tab);

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -3570,19 +3570,18 @@ ScriptEditor::~ScriptEditor() {
 	memdelete(completion_cache);
 }
 
-void ScriptEditor::resolve_root_script_move(const String &p_root_script_path) {
-    // FIXME: this method closes unattached/inner scripts, should just check if it's open
-    // TODO: Find way to get path of current scene tab's script, instead of this bullshit
-    // TODO: ! additional note, the path also may not be necessary, as this behavior only occurs with the root node's script
-
+// TODO, the bug persists for all scripts attached in the current tab, should do search for all attached script
+// TODO: renamed this to be more analogous for getting rid of currently attached [unsaved]'s
+void ScriptEditor::resolve_current_scene_move(int p_scene_tab) {
+    String root_script_path = editor->get_editor_data().get_scene_root_script(p_scene_tab)->get_path();
     for (int i = 0; i < tab_container->get_child_count(); ++i) {
         ScriptEditorBase *seb = Object::cast_to<ScriptEditorBase>(tab_container->get_child(i));
         if (!seb) {
             continue;
         }
 
-        print_verbose(vformat("Provided path: (%s), current path: (%s)", p_root_script_path, seb->get_edited_resource()->get_path()));
-        if (seb->get_edited_resource()->get_path() == p_root_script_path) {
+        print_verbose(vformat("Provided path: (%s), current path: (%s)", root_script_path, seb->get_edited_resource()->get_path()));
+        if (seb->get_edited_resource()->get_path() == root_script_path) {
             _close_tab(i, false, false);
             break;
         }

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -3570,18 +3570,21 @@ ScriptEditor::~ScriptEditor() {
 	memdelete(completion_cache);
 }
 
-void ScriptEditor::close_moved_script(const String &p_rename) {
+void ScriptEditor::resolve_root_script_move(const String &p_root_script_path) {
     // FIXME: this method closes unattached/inner scripts, should just check if it's open
     // TODO: Find way to get path of current scene tab's script, instead of this bullshit
     // TODO: ! additional note, the path also may not be necessary, as this behavior only occurs with the root node's script
 
-    Vector<Ref<Script>> open_scripts = get_open_scripts();
+    for (int i = 0; i < tab_container->get_child_count(); ++i) {
+        ScriptEditorBase *seb = Object::cast_to<ScriptEditorBase>(tab_container->get_child(i));
+        if (!seb) {
+            continue;
+        }
 
-    for (int i = 0; i < open_scripts.size(); ++i) {
-        print_verbose("new path: " + p_rename + ", \ncurrent path: " + open_scripts[i]->get_path());
-
-        if (open_scripts[i]->get_path() == p_rename) {
+        print_verbose(vformat("Provided path: (%s), current path: (%s)", p_root_script_path, seb->get_edited_resource()->get_path()));
+        if (seb->get_edited_resource()->get_path() == p_root_script_path) {
             _close_tab(i, false, false);
+            break;
         }
     }
 }

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -3570,6 +3570,22 @@ ScriptEditor::~ScriptEditor() {
 	memdelete(completion_cache);
 }
 
+void ScriptEditor::close_moved_script(const String &p_rename) {
+    // FIXME: this method closes unattached/inner scripts, should just check if it's open
+    // TODO: Find way to get path of current scene tab's script, instead of this bullshit
+    // TODO: ! additional note, the path also may not be necessary, as this behavior only occurs with the root node's script
+
+    Vector<Ref<Script>> open_scripts = get_open_scripts();
+
+    for (int i = 0; i < open_scripts.size(); ++i) {
+        print_verbose("new path: " + p_rename + ", \ncurrent path: " + open_scripts[i]->get_path());
+
+        if (open_scripts[i]->get_path() == p_rename) {
+            _close_tab(i, false, false);
+        }
+    }
+}
+
 void ScriptEditorPlugin::edit(Object *p_object) {
 	if (Object::cast_to<Script>(p_object)) {
 		Script *p_script = Object::cast_to<Script>(p_object);

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -435,7 +435,7 @@ public:
 
 	void save_current_script();
 	void save_all_scripts();
-    void resolve_root_script_move(const String &p_root_script_path);
+    void resolve_current_scene_move(int p_scene_tab);
 
 	void set_window_layout(Ref<ConfigFile> p_layout);
 	void get_window_layout(Ref<ConfigFile> p_layout);

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -435,7 +435,7 @@ public:
 
 	void save_current_script();
 	void save_all_scripts();
-    void close_moved_script(const String &p_rename);
+    void resolve_root_script_move(const String &p_root_script_path);
 
 	void set_window_layout(Ref<ConfigFile> p_layout);
 	void get_window_layout(Ref<ConfigFile> p_layout);

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -435,7 +435,7 @@ public:
 
 	void save_current_script();
 	void save_all_scripts();
-    void resolve_current_scene_move(int p_scene_tab);
+    void resolve_current_scene_move(int p_scene_tab, const String &p_old_path, const String &p_new_path);
 
 	void set_window_layout(Ref<ConfigFile> p_layout);
 	void get_window_layout(Ref<ConfigFile> p_layout);

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -435,6 +435,7 @@ public:
 
 	void save_current_script();
 	void save_all_scripts();
+    void close_moved_script(const String &p_rename);
 
 	void set_window_layout(Ref<ConfigFile> p_layout);
 	void get_window_layout(Ref<ConfigFile> p_layout);

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -435,7 +435,7 @@ public:
 
 	void save_current_script();
 	void save_all_scripts();
-    void resolve_current_scene_move(int p_scene_tab, const String &p_old_path, const String &p_new_path);
+    void resolve_edited_scene_move(int p_scene_tab, const String &p_old_path, const String &p_new_path);
 
 	void set_window_layout(Ref<ConfigFile> p_layout);
 	void get_window_layout(Ref<ConfigFile> p_layout);

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -435,7 +435,7 @@ public:
 
 	void save_current_script();
 	void save_all_scripts();
-    void resolve_edited_scene_move(int p_scene_tab, const String &p_old_path, const String &p_new_path);
+	void resolve_edited_scene_move(int p_scene_tab, const String &p_old_path, const String &p_new_path);
 
 	void set_window_layout(Ref<ConfigFile> p_layout);
 	void get_window_layout(Ref<ConfigFile> p_layout);


### PR DESCRIPTION
When moving a script attached to a node of the current scene tab, if they are open in the script editor, the old tab is replaced with a new one with the identical source of the moved script. 

https://user-images.githubusercontent.com/57271984/203875236-348c4339-fc52-405c-8aef-9c6c45af796a.mp4

This handles that move with a new method: `ScriptEditor::resolve_edited_scene_move`, that closes the original tabs, and sends requests to reopen the moved scripts.

https://user-images.githubusercontent.com/57271984/203875456-0b56f6d1-40b3-4bcf-97ac-c8604eddfdec.mp4

